### PR TITLE
Process long CLI args properly

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,27 +34,34 @@ const cli = meow([`
   }
 }])
 
-const token = cli.flags.t || process.env.GITHUB_TOKEN
+const user = cli.flags.u || cli.flags.user
+const repo = cli.flags.r || cli.flags.repo
+const org = cli.flags.o || cli.flags.org
 
-const after = cli.flags.a && new Date(cli.flags.a)
-const before = cli.flags.b && new Date(cli.flags.b)
+const a = cli.flags.a || cli.flags.after
+const b = cli.flags.b || cli.flags.before
+const after = a && new Date(a)
+const before = b && new Date(b)
 
-if (cli.flags.o && token) {
+const token = cli.flags.t || cli.flags.token || process.env.GITHUB_TOKEN
+
+
+if (org && token) {
   main.orgContributors({
-    token: token,
-    orgName: cli.flags.o,
-    before: before,
-    after: after
+    orgName: org,
+    token,
+    before,
+    after
   }).then(json => JSON.stringify(json, null, 2))
     .then(console.log)
     .catch(e => console.error(e.message))
-} else if (cli.flags.u && cli.flags.r && token) {
+} else if (user && repo && token) {
   main.repoContributors({
-    token: token,
-    user: cli.flags.u,
-    repo: cli.flags.r,
-    before: before,
-    after: after
+    token,
+    user,
+    repo,
+    before,
+    after
   }).then(x => JSON.stringify(x, null, 2))
     .then(console.log)
     .catch(e => console.error(e.message))

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,7 +45,6 @@ const before = b && new Date(b)
 
 const token = cli.flags.t || cli.flags.token || process.env.GITHUB_TOKEN
 
-
 if (org && token) {
   main.orgContributors({
     orgName: org,


### PR DESCRIPTION
There was an error in the command line arg processing where long options (`--after`, etc.) were being dropped. This should fix it.

Addresses #14 